### PR TITLE
remove the `uninstal` directive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 *.egg-info
+__pycache__

--- a/Makefile
+++ b/Makefile
@@ -24,12 +24,6 @@ clean:
 	@rm -fr packgenlite/version.txt
 	@find . -name \*.pyc -o -name \*.pyo -o -name __pycache__ -exec rm -rf {} +
 
-
-uninstal:
-	@python setup.py install --record files.txt
-	@cat files.txt | xargs rm -rf
-	@rm -f files.txt
-
 python_count_lines:
 	@find ./ble -name '*.py' -exec  wc -l {} \; | sort -n| awk \
         '{printf "%4s %s\n", $$1, $$2}{s+=$$0}END{print s}'

--- a/packgenlite/data/skeleton/Makefile
+++ b/packgenlite/data/skeleton/Makefile
@@ -30,12 +30,6 @@ install:
 
 all: clean install test black check_code
 
-
-uninstal:
-	@python setup.py install --record files.txt
-	@cat files.txt | xargs rm -rf
-	@rm -f files.txt
-
 count_lines:
 	@find ./ -name '*.py' -exec  wc -l {} \; | sort -n| awk \
         '{printf "%4s %s\n", $$1, $$2}{s+=$$0}END{print s}'

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ requirements = [x.strip() for x in content if 'git+' not in x]
 
 
 setup(name='packgenlite',
-      version="1.1.2",
+      version="1.1.3",
       # Below to deal with cleaner versionning
       #setup_requires=['setuptools_scm'],
       install_requires=requirements,


### PR DESCRIPTION
the `uninstal` Makefile directive removed amongst other things the `pip` command from the binaries of the current virtual env

after running the command it was necessary to manually reinstall `pip`

the directive starts by creating a `files.txt` list of packages installed by the install command of the generated package (here `poi`). This file contains the path to many binaries of the virtual env, amongst which pip

then the directive removes recursively each of the path in `files.txt` before removing `files.txt` 🎉

`files.txt` for a generated package named `poi` :
```
/Users/gmanchon/.pyenv/versions/3.9.2/envs/py_392/lib/python3.9/site-packages/poi-1.0-py3.9.egg/tests/__init__.py
/Users/gmanchon/.pyenv/versions/3.9.2/envs/py_392/lib/python3.9/site-packages/poi-1.0-py3.9.egg/tests/__pycache__/__init__.cpython-39.pyc
/Users/gmanchon/.pyenv/versions/3.9.2/envs/py_392/lib/python3.9/site-packages/poi-1.0-py3.9.egg/EGG-INFO/PKG-INFO
/Users/gmanchon/.pyenv/versions/3.9.2/envs/py_392/lib/python3.9/site-packages/poi-1.0-py3.9.egg/EGG-INFO/not-zip-safe
/Users/gmanchon/.pyenv/versions/3.9.2/envs/py_392/lib/python3.9/site-packages/poi-1.0-py3.9.egg/EGG-INFO/SOURCES.txt
/Users/gmanchon/.pyenv/versions/3.9.2/envs/py_392/lib/python3.9/site-packages/poi-1.0-py3.9.egg/EGG-INFO/requires.txt
/Users/gmanchon/.pyenv/versions/3.9.2/envs/py_392/lib/python3.9/site-packages/poi-1.0-py3.9.egg/EGG-INFO/top_level.txt
/Users/gmanchon/.pyenv/versions/3.9.2/envs/py_392/lib/python3.9/site-packages/poi-1.0-py3.9.egg/EGG-INFO/dependency_links.txt
/Users/gmanchon/.pyenv/versions/3.9.2/envs/py_392/lib/python3.9/site-packages/poi-1.0-py3.9.egg/EGG-INFO/scripts/poi-run
/Users/gmanchon/.pyenv/versions/3.9.2/envs/py_392/lib/python3.9/site-packages/poi-1.0-py3.9.egg/poi/__init__.py
/Users/gmanchon/.pyenv/versions/3.9.2/envs/py_392/lib/python3.9/site-packages/poi-1.0-py3.9.egg/poi/__pycache__/__init__.cpython-39.pyc
/Users/gmanchon/.pyenv/versions/3.9.2/envs/py_392/lib/python3.9/site-packages/poi-1.0-py3.9.egg/poi/data/.keep
/Users/gmanchon/.pyenv/versions/py_392/bin/poi-run
/Users/gmanchon/.pyenv/versions/py_392/bin/mlflow
/Users/gmanchon/.pyenv/versions/py_392/bin/yapf
/Users/gmanchon/.pyenv/versions/py_392/bin/yapf-diff
/Users/gmanchon/.pyenv/versions/py_392/bin/py.test
/Users/gmanchon/.pyenv/versions/py_392/bin/pytest
/Users/gmanchon/.pyenv/versions/py_392/bin/flake8
/Users/gmanchon/.pyenv/versions/py_392/bin/coverage
/Users/gmanchon/.pyenv/versions/py_392/bin/coverage-3.9
/Users/gmanchon/.pyenv/versions/py_392/bin/coverage3
/Users/gmanchon/.pyenv/versions/py_392/bin/black
/Users/gmanchon/.pyenv/versions/py_392/bin/black-primer
/Users/gmanchon/.pyenv/versions/py_392/bin/blackd
/Users/gmanchon/.pyenv/versions/py_392/bin/f2py
/Users/gmanchon/.pyenv/versions/py_392/bin/f2py3
/Users/gmanchon/.pyenv/versions/py_392/bin/f2py3.9
/Users/gmanchon/.pyenv/versions/py_392/bin/wheel
/Users/gmanchon/.pyenv/versions/py_392/bin/twine
/Users/gmanchon/.pyenv/versions/py_392/bin/easy_install
/Users/gmanchon/.pyenv/versions/py_392/bin/easy_install-3.8
/Users/gmanchon/.pyenv/versions/py_392/bin/pip
/Users/gmanchon/.pyenv/versions/py_392/bin/pip3
/Users/gmanchon/.pyenv/versions/py_392/bin/pip3.8
/Users/gmanchon/.pyenv/versions/py_392/bin/alembic
/Users/gmanchon/.pyenv/versions/py_392/bin/gunicorn
/Users/gmanchon/.pyenv/versions/py_392/bin/flask
/Users/gmanchon/.pyenv/versions/py_392/bin/databricks
/Users/gmanchon/.pyenv/versions/py_392/bin/dbfs
/Users/gmanchon/.pyenv/versions/py_392/bin/sqlformat
/Users/gmanchon/.pyenv/versions/py_392/bin/google-oauthlib-tool
/Users/gmanchon/.pyenv/versions/py_392/bin/pycodestyle
/Users/gmanchon/.pyenv/versions/py_392/bin/pyflakes
/Users/gmanchon/.pyenv/versions/py_392/bin/pkginfo
/Users/gmanchon/.pyenv/versions/py_392/bin/keyring
/Users/gmanchon/.pyenv/versions/py_392/bin/tqdm
/Users/gmanchon/.pyenv/versions/py_392/bin/mako-render
/Users/gmanchon/.pyenv/versions/py_392/bin/tabulate
/Users/gmanchon/.pyenv/versions/py_392/bin/chardetect
/Users/gmanchon/.pyenv/versions/py_392/bin/pyrsa-decrypt
/Users/gmanchon/.pyenv/versions/py_392/bin/pyrsa-encrypt
/Users/gmanchon/.pyenv/versions/py_392/bin/pyrsa-keygen
/Users/gmanchon/.pyenv/versions/py_392/bin/pyrsa-priv2pub
/Users/gmanchon/.pyenv/versions/py_392/bin/pyrsa-sign
/Users/gmanchon/.pyenv/versions/py_392/bin/pyrsa-verify
/Users/gmanchon/.pyenv/versions/py_392/bin/pygmentize
```
