### PR TITLE
add mypy initial set up

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,4 @@
+[mypy]
+plugins = numpy.typing.mypy_plugin
+ignore_missing_imports = True
+exclude='**/tests'

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,8 @@ setuptools>=26
 wheel>=0.29
 setuptools_scm
 future
+numpy
 pandas
+pandas-stubs
+mypy
 python-gitlab


### PR DESCRIPTION
**Goal : add static type checking from day 1 in a new project**

1. Add `mypy`, `pandas-stubs` in `requirements.txt`
2. Add a `mypy.ini` to [configure mypy's behaviour](https://mypy.readthedocs.io/en/stable/config_file.html)
3. Set `plugins = numpy.typing.mypy_plugin` to enable numpy's built-in type checking [(New in Numpy version 1.20.) ](https://numpy.org/devdocs/reference/typing.html)
4. Set `ignore_missing_imports = True` to [skip external libraries that do not support type checking](#https://github.com/matangover/mypy-vscode/issues/6)
5. Set `exclude='**/tests'` to avoid duplicate module name problem


Obs: this set up should work with [this VSCode plugin ](https://marketplace.visualstudio.com/items?itemName=matangover.mypy)

Example of problems detected by mypy upon installing packgenlite (created and solved by this commit) : 

4. `Skipping analyzing "setuptools": found module but no type hints or library stubs // See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports`

5. `"Duplicate module named \"tests\" (also at \"./packgenlite/data/skeleton/tests/__init__.py\")" //  "Are you missing an __init__.py? Alternatively, consider using --exclude to avoid checking one of them.",`